### PR TITLE
increase component lifetime slider range

### DIFF
--- a/Source/Fluffy_Breakdowns/Settings.cs
+++ b/Source/Fluffy_Breakdowns/Settings.cs
@@ -19,7 +19,7 @@ namespace Fluffy_Breakdowns
 
             // difficulty setting
             list.Label( "FluffyBreakdowns.ComponentLifetimeFactor".Translate( ComponentLifetime.ToStringPercent() ) );
-            ComponentLifetime = list.Slider( ComponentLifetime, .5f, 2f );
+            ComponentLifetime = list.Slider( ComponentLifetime, .1f, 10f );
 
             // not used degradation factor
             list.Label("FluffyBreakdowns.NotUsedFactor".Translate(NotUsedFactor.ToStringPercent()));


### PR DESCRIPTION
was 50% -> 200%
now 10% -> 1000%

This should allow people who want to reduce their maintenance budget to easily do so.
And I suppose if anyone out there wants the challenge of continuous repairs.. Who am I to judge.